### PR TITLE
pint test

### DIFF
--- a/test_pint.py
+++ b/test_pint.py
@@ -1,0 +1,24 @@
+import pint
+import metrology_apis as mt
+
+Quantity = pint.Quantity
+Unit = pint.Unit
+
+
+def test_eq(q: mt.Quantity) -> None:
+    print(q == q)
+
+def test_unit(q: mt.Quantity) -> None:
+    print(q.unit)
+
+def test_value(q: mt.Quantity) -> None:
+    print(q.value)
+
+def test_m(q: mt.Quantity) -> None:
+    print(q.m)
+
+
+test_eq(Quantity(1, "m"))
+test_unit(Quantity(1, "m"))
+test_value(Quantity(1, "m"))
+# test_m(Quantity(1, "m")) #error: "Quantity[Any, Any]" has no attribute "m"  [attr-defined]


### PR DESCRIPTION
with this branch https://github.com/quantity-dev/pint/tree/metrology that adds `Quantity.value` to pint's `Quantity`, mypy runs without errors (and errors if I try to access `Quantity.m`)

are there any examples on good ways to organise this code?